### PR TITLE
Add Aula model and integrate with scheduling

### DIFF
--- a/alembic/versions/5facc1ba8584_add_aula_model.py
+++ b/alembic/versions/5facc1ba8584_add_aula_model.py
@@ -1,0 +1,41 @@
+"""add aula model
+
+Revision ID: 5facc1ba8584
+Revises: 
+Create Date: 2025-09-07 05:19:42.429139
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5facc1ba8584'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'aulas',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('nombre', sa.String(length=100), nullable=False, unique=True),
+        sa.Column('capacidad', sa.Integer(), nullable=True),
+    )
+    op.add_column('clases_programadas', sa.Column('aula_id', sa.Integer(), nullable=False))
+    op.create_foreign_key(
+        'fk_clases_programadas_aula_id',
+        'clases_programadas',
+        'aulas',
+        ['aula_id'],
+        ['id'],
+    )
+    op.drop_column('clases_programadas', 'aula')
+
+
+def downgrade():
+    op.add_column('clases_programadas', sa.Column('aula', sa.String(), nullable=False))
+    op.drop_constraint('fk_clases_programadas_aula_id', 'clases_programadas', type_='foreignkey')
+    op.drop_column('clases_programadas', 'aula_id')
+    op.drop_table('aulas')

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from app.routers import asignacion_materia
 from app.routers import clase_programada
 from app.routers import horarios
 from app.routers import disponibilidad  # <-- ✅ ESTE ES NUEVO
+from app.routers import aula
 from app.routers.auth import auth_router
 
 
@@ -28,6 +29,7 @@ def create_app():
     app.include_router(docente.router)
     app.include_router(asignacion_materia.router)
     app.include_router(clase_programada.router)
+    app.include_router(aula.router)
     app.include_router(horarios.router)
     app.include_router(disponibilidad.router)  # <-- ✅ AQUÍ LO AÑADES
     app.include_router(auth_router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -7,3 +7,4 @@ from app.models.asignacion_materia import AsignacionMateria
 from app.models.clase_programada import ClaseProgramada
 from app.models.admin import Admin
 from .disponibilidad_docente import DisponibilidadDocente
+from app.models.aula import Aula

--- a/app/models/aula.py
+++ b/app/models/aula.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
+from app.core.database import Base
+
+
+class Aula(Base):
+    __tablename__ = "aulas"
+
+    id = Column(Integer, primary_key=True, index=True)
+    nombre = Column(String(100), nullable=False, unique=True)
+    capacidad = Column(Integer, nullable=True)
+
+    clases = relationship("ClaseProgramada", back_populates="aula", cascade="all, delete")

--- a/app/models/clase_programada.py
+++ b/app/models/clase_programada.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, ForeignKey, Time, Enum, String
+from sqlalchemy import Column, Integer, ForeignKey, Time, Enum
 from sqlalchemy.orm import relationship
 from app.core.database import Base
 from app.enums import DiaSemanaEnum
@@ -9,10 +9,11 @@ class ClaseProgramada(Base):
     id = Column(Integer, primary_key=True, index=True)
     docente_id = Column(Integer, ForeignKey("docentes.id"))
     materia_id = Column(Integer, ForeignKey("materias.id"))
-    aula = Column(String, nullable=False)
+    aula_id = Column(Integer, ForeignKey("aulas.id"), nullable=False)
     dia = Column(Enum(DiaSemanaEnum), nullable=False)
     hora_inicio = Column(Time, nullable=False)
     hora_fin = Column(Time, nullable=False)
 
     docente = relationship("Docente", back_populates="clases")
     materia = relationship("Materia", back_populates="clases")
+    aula = relationship("Aula", back_populates="clases")

--- a/app/routers/aula.py
+++ b/app/routers/aula.py
@@ -1,0 +1,62 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+from app.core.database import get_db
+from app.models.aula import Aula
+from app.schemas.aula import AulaCreate, AulaResponse, AulaUpdate
+
+router = APIRouter(prefix="/aulas", tags=["Aulas"])
+
+
+@router.get("/", response_model=List[AulaResponse])
+def listar_aulas(db: Session = Depends(get_db)):
+    return db.query(Aula).all()
+
+
+@router.post("/", response_model=AulaResponse)
+def crear_aula(aula: AulaCreate, db: Session = Depends(get_db)):
+    nueva = Aula(**aula.dict())
+    db.add(nueva)
+    try:
+        db.commit()
+        db.refresh(nueva)
+    except Exception:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Error al crear el aula")
+    return nueva
+
+
+@router.get("/{aula_id}", response_model=AulaResponse)
+def obtener_aula(aula_id: int, db: Session = Depends(get_db)):
+    aula = db.query(Aula).filter(Aula.id == aula_id).first()
+    if aula is None:
+        raise HTTPException(status_code=404, detail="Aula no encontrada")
+    return aula
+
+
+@router.put("/{aula_id}", response_model=AulaResponse)
+def actualizar_aula(aula_id: int, datos: AulaUpdate, db: Session = Depends(get_db)):
+    aula = db.query(Aula).filter(Aula.id == aula_id).first()
+    if aula is None:
+        raise HTTPException(status_code=404, detail="Aula no encontrada")
+
+    for key, value in datos.dict(exclude_unset=True).items():
+        setattr(aula, key, value)
+
+    try:
+        db.commit()
+        db.refresh(aula)
+    except Exception:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Error al actualizar el aula")
+    return aula
+
+
+@router.delete("/{aula_id}", status_code=204)
+def eliminar_aula(aula_id: int, db: Session = Depends(get_db)):
+    aula = db.query(Aula).filter(Aula.id == aula_id).first()
+    if aula is None:
+        raise HTTPException(status_code=404, detail="Aula no encontrada")
+
+    db.delete(aula)
+    db.commit()

--- a/app/routers/clase_programada.py
+++ b/app/routers/clase_programada.py
@@ -10,6 +10,7 @@ from app.schemas.clase_programada import (
     ClaseProgramadaUpdate,
     ClaseProgramadaResponse,
 )
+from app.schemas.aula import AulaResponse
 from app.models.clase_programada import ClaseProgramada
 from app.core.database import get_db
 from app.services import verificar_conflictos
@@ -27,7 +28,7 @@ def crear_clase_programada(clase: ClaseProgramadaCreate, db: Session = Depends(g
     conflicto = verificar_conflictos(
         db=db,
         docente_id=clase.docente_id,
-        aula=clase.aula,
+        aula_id=clase.aula_id,
         dia=clase.dia,
         hora_inicio=clase.hora_inicio,
         hora_fin=clase.hora_fin,
@@ -61,7 +62,7 @@ def actualizar_clase_programada(
     conflicto = verificar_conflictos(
         db=db,
         docente_id=clase_actualizada.docente_id,
-        aula=clase_actualizada.aula,
+        aula_id=clase_actualizada.aula_id,
         dia=clase_actualizada.dia,
         hora_inicio=clase_actualizada.hora_inicio,
         hora_fin=clase_actualizada.hora_fin,
@@ -92,7 +93,7 @@ def eliminar_clase_programada(clase_id: int, db: Session = Depends(get_db)):
     db.commit()
 
 
-@router.get("/aulas/disponibles", response_model=List[str])
+@router.get("/aulas/disponibles", response_model=List[AulaResponse])
 def aulas_disponibles(
     dia: DiaSemanaEnum = Query(..., description="Día de la semana"),
     hora_inicio: time = Query(..., description="Hora inicio en formato HH:MM"),

--- a/app/routers/horarios.py
+++ b/app/routers/horarios.py
@@ -24,7 +24,7 @@ def obtener_horario_docente(docente_id: int, db: Session = Depends(get_db)):
     clases_formateadas = [
         ClaseHorario(
             materia=clase.materia.nombre,
-            aula=clase.aula,
+            aula=clase.aula.nombre,
             dia=clase.dia,
             hora_inicio=clase.hora_inicio,
             hora_fin=clase.hora_fin,

--- a/app/schemas/aula.py
+++ b/app/schemas/aula.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class AulaBase(BaseModel):
+    nombre: str
+    capacidad: Optional[int] = None
+
+
+class AulaCreate(AulaBase):
+    pass
+
+
+class AulaResponse(AulaBase):
+    id: int
+
+    class Config:
+        from_attributes = True
+
+
+class AulaUpdate(BaseModel):
+    nombre: Optional[str] = None
+    capacidad: Optional[int] = None

--- a/app/schemas/clase_programada.py
+++ b/app/schemas/clase_programada.py
@@ -6,7 +6,7 @@ from app.enums import DiaSemanaEnum
 class ClaseProgramadaBase(BaseModel):
     docente_id: int = Field(..., gt=0)
     materia_id: int = Field(..., gt=0)
-    aula: str
+    aula_id: int = Field(..., gt=0)
     dia: DiaSemanaEnum
     hora_inicio: time
     hora_fin: time

--- a/app/services/exportar_excel.py
+++ b/app/services/exportar_excel.py
@@ -28,7 +28,7 @@ def generar_excel_horario(clases: List[ClaseProgramada], nombre_docente: str) ->
     for clase in clases:
         ws.append([
             clase.materia.nombre,
-            clase.aula,
+            clase.aula.nombre,
             clase.dia,
             clase.hora_inicio.strftime("%H:%M"),
             clase.hora_fin.strftime("%H:%M"),

--- a/app/services/verificar_conflictos.py
+++ b/app/services/verificar_conflictos.py
@@ -5,7 +5,7 @@ from app.models.materia import Materia
 def verificar_conflictos(
     db: Session,
     docente_id: int,
-    aula: str,
+    aula_id: int,
     dia: str,
     hora_inicio,
     hora_fin,
@@ -19,7 +19,7 @@ def verificar_conflictos(
     Args:
         db: Sesión de base de datos.
         docente_id: ID del docente.
-        aula: Nombre del aula.
+        aula_id: ID del aula.
         dia: Día de la semana.
         hora_inicio: Hora de inicio de la clase.
         hora_fin: Hora de fin de la clase.
@@ -38,8 +38,8 @@ def verificar_conflictos(
         ClaseProgramada.hora_inicio < hora_fin,
         ClaseProgramada.hora_fin > hora_inicio,
         (
-            (ClaseProgramada.docente_id == docente_id) |
-            (ClaseProgramada.aula == aula)
+        (ClaseProgramada.docente_id == docente_id) |
+            (ClaseProgramada.aula_id == aula_id)
         )
     )
 


### PR DESCRIPTION
## Summary
- add Aula SQLAlchemy model and CRUD endpoints
- link ClaseProgramada to Aula via aula_id and provide Alembic migration
- update services and schemas to support Aula-based availability and conflict checks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd1556e9d48322b3b6ec6a312e1f8a