### PR TITLE
Seed demo admin user for demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # backend-horarios
+
+## Demo credentials
+
+The development database includes an initial administrative user for testing:
+
+| Role  | Username | Password  |
+|-------|----------|-----------|
+| Admin | `admin`  | `admin123` |
+
+Use these credentials to sign in during demos.
+

--- a/demo_seed.sql
+++ b/demo_seed.sql
@@ -1,3 +1,7 @@
+-- Admins
+INSERT INTO admins (username, hashed_password) VALUES
+('admin', '$2b$12$EsZwlXKvHEvnxkzuiPKvQ.3uc2h2zcoUq39YDj/86BMhIRQwNHQvm');
+
 -- Facultades
 INSERT INTO facultades (nombre) VALUES
 ('Facultad de Ingeniería'),


### PR DESCRIPTION
## Summary
- add demo admin with bcrypt hashed password to `demo_seed.sql`
- document demo admin credentials in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd157cddd08322bcc3436054bd5c12