### PR TITLE
Add tests for schedule conflict checks and availability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+*.pyc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.core.database import Base
+from app.models.facultad import Facultad
+from app.models.plan_estudio import PlanEstudio
+from app.models.docente import Docente
+from app.models.materia import Materia
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def basic_data(session):
+    facultad = Facultad(nombre="Ingeniería")
+    plan = PlanEstudio(nombre="Plan 2024", facultad=facultad)
+    docente1 = Docente(nombre="Docente Uno", correo="d1@example.com", numero_empleado="1", facultad=facultad)
+    docente2 = Docente(nombre="Docente Dos", correo="d2@example.com", numero_empleado="2", facultad=facultad)
+    materia = Materia(nombre="Mat", codigo="MAT1", creditos=3, plan_estudio=plan, permite_superposicion=False)
+    materia_super = Materia(nombre="Mat Sup", codigo="MAT2", creditos=3, plan_estudio=plan, permite_superposicion=True)
+    session.add_all([facultad, plan, docente1, docente2, materia, materia_super])
+    session.commit()
+    return {
+        "docente1": docente1,
+        "docente2": docente2,
+        "materia": materia,
+        "materia_super": materia_super,
+    }

--- a/tests/test_disponibilidad_docente.py
+++ b/tests/test_disponibilidad_docente.py
@@ -1,0 +1,60 @@
+from datetime import time
+
+from app.enums import DiaSemanaEnum
+from app.models.clase_programada import ClaseProgramada
+from app.schemas.disponibilidad_docente import BloqueDisponible, DisponibilidadDocenteMultipleCreate
+from app.routers.disponibilidad import crear_disponibilidad
+from app.services.disponibilidad_docente import obtener_disponibilidad_docente, obtener_bloques_disponibles_registrados
+
+
+def test_obtener_disponibilidad_docente(session, basic_data):
+    docente = basic_data["docente1"]
+    materia = basic_data["materia"]
+    clase1 = ClaseProgramada(
+        docente_id=docente.id,
+        materia_id=materia.id,
+        aula="A1",
+        dia=DiaSemanaEnum.lunes,
+        hora_inicio=time(9, 0),
+        hora_fin=time(10, 0),
+    )
+    clase2 = ClaseProgramada(
+        docente_id=docente.id,
+        materia_id=materia.id,
+        aula="A1",
+        dia=DiaSemanaEnum.lunes,
+        hora_inicio=time(11, 0),
+        hora_fin=time(12, 0),
+    )
+    session.add_all([clase1, clase2])
+    session.commit()
+
+    bloques = obtener_disponibilidad_docente(
+        db=session,
+        docente_id=docente.id,
+        dia=DiaSemanaEnum.lunes,
+        desde=time(8, 0),
+        hasta=time(12, 0),
+    )
+    assert bloques == [
+        {"dia": DiaSemanaEnum.lunes, "hora_inicio": time(8, 0), "hora_fin": time(9, 0)},
+        {"dia": DiaSemanaEnum.lunes, "hora_inicio": time(10, 0), "hora_fin": time(11, 0)},
+    ]
+
+
+def test_insercion_disponibilidad(session, basic_data):
+    docente = basic_data["docente1"]
+    payload = DisponibilidadDocenteMultipleCreate(
+        docente_id=docente.id,
+        disponibles=[
+            BloqueDisponible(dia=DiaSemanaEnum.lunes, hora_inicio=time(8, 0), hora_fin=time(9, 0)),
+            BloqueDisponible(dia=DiaSemanaEnum.martes, hora_inicio=time(10, 0), hora_fin=time(11, 0)),
+        ],
+    )
+
+    crear_disponibilidad(payload, db=session)
+
+    bloques = obtener_bloques_disponibles_registrados(session, docente.id)
+    assert len(bloques) == 2
+    assert bloques[0]["dia"] == DiaSemanaEnum.lunes
+    assert bloques[1]["dia"] == DiaSemanaEnum.martes

--- a/tests/test_verificar_conflictos.py
+++ b/tests/test_verificar_conflictos.py
@@ -1,0 +1,85 @@
+from datetime import time
+
+from app.enums import DiaSemanaEnum
+from app.models.clase_programada import ClaseProgramada
+from app.services.verificar_conflictos import verificar_conflictos
+
+
+def test_conflicto_por_docente(session, basic_data):
+    docente = basic_data["docente1"]
+    materia = basic_data["materia"]
+    clase = ClaseProgramada(
+        docente_id=docente.id,
+        materia_id=materia.id,
+        aula="A1",
+        dia=DiaSemanaEnum.lunes,
+        hora_inicio=time(9, 0),
+        hora_fin=time(10, 0),
+    )
+    session.add(clase)
+    session.commit()
+
+    conflicto = verificar_conflictos(
+        db=session,
+        docente_id=docente.id,
+        aula="A2",
+        dia=DiaSemanaEnum.lunes,
+        hora_inicio=time(9, 30),
+        hora_fin=time(10, 30),
+        materia_id=materia.id,
+    )
+    assert conflicto is True
+
+
+def test_conflicto_por_aula(session, basic_data):
+    docente1 = basic_data["docente1"]
+    docente2 = basic_data["docente2"]
+    materia = basic_data["materia"]
+    clase = ClaseProgramada(
+        docente_id=docente1.id,
+        materia_id=materia.id,
+        aula="A1",
+        dia=DiaSemanaEnum.lunes,
+        hora_inicio=time(9, 0),
+        hora_fin=time(10, 0),
+    )
+    session.add(clase)
+    session.commit()
+
+    conflicto = verificar_conflictos(
+        db=session,
+        docente_id=docente2.id,
+        aula="A1",
+        dia=DiaSemanaEnum.lunes,
+        hora_inicio=time(9, 30),
+        hora_fin=time(10, 30),
+        materia_id=materia.id,
+    )
+    assert conflicto is True
+
+
+def test_superposicion_permitida(session, basic_data):
+    docente = basic_data["docente1"]
+    materia = basic_data["materia"]
+    materia_super = basic_data["materia_super"]
+    clase = ClaseProgramada(
+        docente_id=docente.id,
+        materia_id=materia.id,
+        aula="A1",
+        dia=DiaSemanaEnum.lunes,
+        hora_inicio=time(9, 0),
+        hora_fin=time(10, 0),
+    )
+    session.add(clase)
+    session.commit()
+
+    conflicto = verificar_conflictos(
+        db=session,
+        docente_id=docente.id,
+        aula="A1",
+        dia=DiaSemanaEnum.lunes,
+        hora_inicio=time(9, 30),
+        hora_fin=time(10, 30),
+        materia_id=materia_super.id,
+    )
+    assert conflicto is False


### PR DESCRIPTION
## Summary
- add pytest suite for verificar_conflictos covering docente/aula conflicts and materias with allowed overlap
- add tests for obtener_disponibilidad_docente and disponibilidad creation
- run tests in CI via GitHub Actions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd157d21588322be61a2b9a805a2f4