### PR TITLE
Add Grupo entity and integrate with class scheduling

### DIFF
--- a/alembic/versions/202406010001_add_grupos_table.py
+++ b/alembic/versions/202406010001_add_grupos_table.py
@@ -1,0 +1,50 @@
+"""add grupos table and link to clases_programadas
+
+Revision ID: 202406010001
+Revises: 202405190000
+Create Date: 2024-06-01 00:00:00
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "202406010001"
+down_revision = "202405190000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "grupos",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("nombre", sa.String(length=100), nullable=False),
+        sa.Column("plan_estudio_id", sa.Integer(), nullable=False),
+        sa.Column("num_estudiantes", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["plan_estudio_id"], ["planes_estudio.id"]),
+    )
+
+    op.add_column(
+        "clases_programadas",
+        sa.Column("grupo_id", sa.Integer(), nullable=False),
+    )
+    op.create_foreign_key(
+        "fk_clases_programadas_grupo_id",
+        "clases_programadas",
+        "grupos",
+        ["grupo_id"],
+        ["id"],
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "fk_clases_programadas_grupo_id",
+        "clases_programadas",
+        type_="foreignkey",
+    )
+    op.drop_column("clases_programadas", "grupo_id")
+    op.drop_table("grupos")

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from app.routers import horarios
 from app.routers import disponibilidad  # <-- ✅ ESTE ES NUEVO
 from app.routers import dias  # <-- ✅ ESTE ES NUEVO
 from app.routers import aula
+from app.routers import grupo
 from app.routers.auth import auth_router
 
 
@@ -31,6 +32,7 @@ def create_app():
     app.include_router(asignacion_materia.router)
     app.include_router(clase_programada.router)
     app.include_router(aula.router)
+    app.include_router(grupo.router)
     app.include_router(horarios.router)
     app.include_router(disponibilidad.router)  # <-- ✅ AQUÍ LO AÑADES
     app.include_router(dias.router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -9,3 +9,4 @@ from app.models.admin import Admin
 from .disponibilidad_docente import DisponibilidadDocente
 from app.models.aula import Aula
 from app.models.timestamp_mixin import TimestampMixin
+from app.models.grupo import Grupo

--- a/app/models/clase_programada.py
+++ b/app/models/clase_programada.py
@@ -11,6 +11,7 @@ class ClaseProgramada(TimestampMixin, Base):
     docente_id = Column(Integer, ForeignKey("docentes.id"))
     materia_id = Column(Integer, ForeignKey("materias.id"))
     aula_id = Column(Integer, ForeignKey("aulas.id"), nullable=False)
+    grupo_id = Column(Integer, ForeignKey("grupos.id"), nullable=False)
     dia = Column(Enum(DiaSemanaEnum), nullable=False)
     hora_inicio = Column(Time, nullable=False)
     hora_fin = Column(Time, nullable=False)
@@ -18,6 +19,7 @@ class ClaseProgramada(TimestampMixin, Base):
     docente = relationship("Docente", back_populates="clases")
     materia = relationship("Materia", back_populates="clases")
     aula = relationship("Aula", back_populates="clases")
+    grupo = relationship("Grupo", back_populates="clases")
     asignacion = relationship(
         "AsignacionMateria",
         primaryjoin=

--- a/app/models/grupo.py
+++ b/app/models/grupo.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from app.core.database import Base
+
+
+class Grupo(Base):
+    __tablename__ = "grupos"
+
+    id = Column(Integer, primary_key=True, index=True)
+    nombre = Column(String(100), nullable=False)
+    plan_estudio_id = Column(Integer, ForeignKey("planes_estudio.id"), nullable=False)
+    num_estudiantes = Column(Integer, nullable=False)
+
+    plan_estudio = relationship("PlanEstudio", back_populates="grupos")
+    clases = relationship(
+        "ClaseProgramada", back_populates="grupo", cascade="all, delete"
+    )

--- a/app/models/plan_estudio.py
+++ b/app/models/plan_estudio.py
@@ -10,5 +10,8 @@ class PlanEstudio(Base):
     facultad_id = Column(Integer, ForeignKey("facultades.id"), nullable=False)
 
     facultad = relationship("Facultad", back_populates="planes")
-    materias = relationship("Materia", back_populates="plan_estudio", cascade="all, delete")
+    materias = relationship(
+        "Materia", back_populates="plan_estudio", cascade="all, delete"
+    )
+    grupos = relationship("Grupo", back_populates="plan_estudio", cascade="all, delete")
 

--- a/app/routers/grupo.py
+++ b/app/routers/grupo.py
@@ -1,0 +1,58 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.models.grupo import Grupo
+from app.schemas.grupo import GrupoCreate, GrupoResponse, GrupoUpdate
+
+router = APIRouter(prefix="/grupos", tags=["Grupos"])
+
+
+@router.get("/", response_model=List[GrupoResponse])
+def listar_grupos(db: Session = Depends(get_db)):
+    return db.query(Grupo).all()
+
+
+@router.get("/{grupo_id}", response_model=GrupoResponse)
+def obtener_grupo(grupo_id: int, db: Session = Depends(get_db)):
+    grupo = db.query(Grupo).filter(Grupo.id == grupo_id).first()
+    if not grupo:
+        raise HTTPException(status_code=404, detail="Grupo no encontrado")
+    return grupo
+
+
+@router.post("/", response_model=GrupoResponse, status_code=status.HTTP_201_CREATED)
+def crear_grupo(grupo: GrupoCreate, db: Session = Depends(get_db)):
+    nuevo_grupo = Grupo(**grupo.dict())
+    db.add(nuevo_grupo)
+    db.commit()
+    db.refresh(nuevo_grupo)
+    return nuevo_grupo
+
+
+@router.put("/{grupo_id}", response_model=GrupoResponse)
+def actualizar_grupo(
+    grupo_id: int, datos: GrupoUpdate, db: Session = Depends(get_db)
+):
+    grupo = db.query(Grupo).filter(Grupo.id == grupo_id).first()
+    if not grupo:
+        raise HTTPException(status_code=404, detail="Grupo no encontrado")
+
+    for key, value in datos.dict(exclude_unset=True).items():
+        setattr(grupo, key, value)
+
+    db.commit()
+    db.refresh(grupo)
+    return grupo
+
+
+@router.delete("/{grupo_id}", status_code=status.HTTP_204_NO_CONTENT)
+def eliminar_grupo(grupo_id: int, db: Session = Depends(get_db)):
+    grupo = db.query(Grupo).filter(Grupo.id == grupo_id).first()
+    if not grupo:
+        raise HTTPException(status_code=404, detail="Grupo no encontrado")
+
+    db.delete(grupo)
+    db.commit()

--- a/app/routers/horarios.py
+++ b/app/routers/horarios.py
@@ -30,6 +30,7 @@ def obtener_horario_docente(docente_id: int, db: Session = Depends(get_db)):
             selectinload(ClaseProgramada.asignacion)
             .selectinload(AsignacionMateria.materia),
             selectinload(ClaseProgramada.aula),
+            selectinload(ClaseProgramada.grupo),
         )
         .filter(ClaseProgramada.docente_id == docente_id)
         .all()
@@ -84,6 +85,7 @@ def obtener_horario_aula(aula_id: int, db: Session = Depends(get_db)):
             selectinload(ClaseProgramada.asignacion)
             .selectinload(AsignacionMateria.materia),
             selectinload(ClaseProgramada.aula),
+            selectinload(ClaseProgramada.grupo),
         )
         .filter(ClaseProgramada.aula_id == aula_id)
         .all()

--- a/app/schemas/clase_programada.py
+++ b/app/schemas/clase_programada.py
@@ -6,12 +6,14 @@ from pydantic import BaseModel, Field, validator
 from app.enums import DiaSemanaEnum
 from app.schemas.asignacion_materia import AsignacionMateriaResponse
 from app.schemas.aula import AulaResponse
+from app.schemas.grupo import GrupoResponse
 
 
 class ClaseProgramadaBase(BaseModel):
     docente_id: int = Field(..., gt=0)
     materia_id: int = Field(..., gt=0)
     aula_id: int = Field(..., gt=0)
+    grupo_id: int = Field(..., gt=0)
     dia: DiaSemanaEnum
     hora_inicio: time
     hora_fin: time
@@ -59,6 +61,7 @@ class ClaseProgramadaResponse(ClaseProgramadaBase):
 class ClaseProgramadaDetalle(ClaseProgramadaResponse):
     asignacion: AsignacionMateriaResponse
     aula: AulaResponse
+    grupo: GrupoResponse
 
     class Config:
         from_attributes = True

--- a/app/schemas/grupo.py
+++ b/app/schemas/grupo.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class GrupoBase(BaseModel):
+    nombre: str = Field(..., min_length=1, max_length=100)
+    plan_estudio_id: int = Field(..., gt=0)
+    num_estudiantes: int = Field(..., ge=0)
+
+
+class GrupoCreate(GrupoBase):
+    pass
+
+
+class GrupoUpdate(BaseModel):
+    nombre: Optional[str] = Field(None, min_length=1, max_length=100)
+    plan_estudio_id: Optional[int] = Field(None, gt=0)
+    num_estudiantes: Optional[int] = Field(None, ge=0)
+
+
+class GrupoResponse(GrupoBase):
+    id: int
+
+    class Config:
+        from_attributes = True

--- a/tests/test_clase_programada.py
+++ b/tests/test_clase_programada.py
@@ -20,6 +20,7 @@ from app.models import (
     Aula,
     ClaseProgramada,
     AsignacionMateria,
+    Grupo,
 )
 from app.enums import DiaSemanaEnum
 
@@ -76,7 +77,8 @@ def crear_datos_base(db):
         creditos=3,
         plan_estudio_id=plan.id,
     )
-    db.add_all([docente, aula, materia])
+    grupo = Grupo(nombre="Grupo A", plan_estudio_id=plan.id, num_estudiantes=25)
+    db.add_all([docente, aula, materia, grupo])
     db.commit()
 
     asignacion = AsignacionMateria(docente_id=docente.id, materia_id=materia.id)
@@ -87,17 +89,25 @@ def crear_datos_base(db):
         docente_id=docente.id,
         materia_id=materia.id,
         aula_id=aula.id,
+        grupo_id=grupo.id,
         dia=DiaSemanaEnum.lunes,
         hora_inicio=time(9, 0),
         hora_fin=time(10, 0),
     )
     db.add(clase)
     db.commit()
-    return docente.id, aula.id, clase.id, materia.id, asignacion.id
+    return docente.id, aula.id, clase.id, materia.id, asignacion.id, grupo.id
 
 
 def test_obtener_clase_programada(client, session):
-    docente_id, aula_id, clase_id, materia_id, asignacion_id = crear_datos_base(session)
+    (
+        docente_id,
+        aula_id,
+        clase_id,
+        materia_id,
+        asignacion_id,
+        grupo_id,
+    ) = crear_datos_base(session)
     response = client.get(f"/clases-programadas/{clase_id}")
     assert response.status_code == 200
     data = response.json()
@@ -112,3 +122,4 @@ def test_obtener_clase_programada(client, session):
     assert data["asignacion"]["docente"]["id"] == docente_id
     assert data["asignacion"]["materia"]["id"] == materia_id
     assert data["aula"]["id"] == aula_id
+    assert data["grupo"]["id"] == grupo_id

--- a/tests/test_horarios.py
+++ b/tests/test_horarios.py
@@ -20,6 +20,7 @@ from app.models import (
     Aula,
     ClaseProgramada,
     AsignacionMateria,
+    Grupo,
 )
 from app.enums import DiaSemanaEnum
 
@@ -76,7 +77,8 @@ def crear_datos_base(db):
         creditos=3,
         plan_estudio_id=plan.id,
     )
-    db.add_all([docente, aula, materia])
+    grupo = Grupo(nombre="Grupo A", plan_estudio_id=plan.id, num_estudiantes=25)
+    db.add_all([docente, aula, materia, grupo])
     db.commit()
 
     asignacion = AsignacionMateria(docente_id=docente.id, materia_id=materia.id)
@@ -87,17 +89,25 @@ def crear_datos_base(db):
         docente_id=docente.id,
         materia_id=materia.id,
         aula_id=aula.id,
+        grupo_id=grupo.id,
         dia=DiaSemanaEnum.lunes,
         hora_inicio=time(9, 0),
         hora_fin=time(10, 0),
     )
     db.add(clase)
     db.commit()
-    return docente.id, aula.id, clase.id, materia.id, asignacion.id
+    return docente.id, aula.id, clase.id, materia.id, asignacion.id, grupo.id
 
 
 def test_horario_docente_devuelve_clases(client, session):
-    docente_id, aula_id, clase_id, materia_id, asignacion_id = crear_datos_base(session)
+    (
+        docente_id,
+        aula_id,
+        clase_id,
+        materia_id,
+        asignacion_id,
+        grupo_id,
+    ) = crear_datos_base(session)
     response = client.get(f"/horarios/docente/{docente_id}")
     assert response.status_code == 200
     data = response.json()
@@ -108,10 +118,18 @@ def test_horario_docente_devuelve_clases(client, session):
     assert clase["asignacion"]["id"] == asignacion_id
     assert clase["asignacion"]["docente"]["id"] == docente_id
     assert clase["aula"]["id"] == aula_id
+    assert clase["grupo"]["id"] == grupo_id
 
 
 def test_horario_aula_devuelve_clases(client, session):
-    docente_id, aula_id, clase_id, materia_id, asignacion_id = crear_datos_base(session)
+    (
+        docente_id,
+        aula_id,
+        clase_id,
+        materia_id,
+        asignacion_id,
+        grupo_id,
+    ) = crear_datos_base(session)
     response = client.get(f"/horarios/aula/{aula_id}")
     assert response.status_code == 200
     data = response.json()
@@ -121,3 +139,4 @@ def test_horario_aula_devuelve_clases(client, session):
     assert clase["id"] == clase_id
     assert clase["asignacion"]["id"] == asignacion_id
     assert clase["aula"]["id"] == aula_id
+    assert clase["grupo"]["id"] == grupo_id


### PR DESCRIPTION
## Summary
- add the Grupo SQLAlchemy model, schemas, and Alembic migration with a CRUD router
- require grupo_id on scheduled classes and expose group information in class and schedule endpoints
- update tests and related routers to account for groups when seeding and querying data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8916acb748322910a24a4998f71d8