### PR TITLE
Validar conflictos por grupo en clases programadas

### DIFF
--- a/app/routers/clase_programada.py
+++ b/app/routers/clase_programada.py
@@ -81,6 +81,7 @@ def crear_clase_programada(clase: ClaseProgramadaCreate, db: Session = Depends(g
         hora_fin=clase.hora_fin,
         materia_id=clase.materia_id,
         aula_id=clase.aula_id,
+        grupo_id=clase.grupo_id,
     )
 
     if not disponible:
@@ -144,6 +145,7 @@ def actualizar_clase_programada(
         hora_fin=clase_actualizada.hora_fin,
         materia_id=clase_actualizada.materia_id,
         aula_id=clase_actualizada.aula_id,
+        grupo_id=clase_actualizada.grupo_id,
         clase_id_ignorar=clase_id,
     )
 

--- a/tests/test_clase_programada.py
+++ b/tests/test_clase_programada.py
@@ -182,3 +182,92 @@ def test_obtener_clase_programada(client, session):
     assert data["asignacion"]["materia"]["id"] == materia_id
     assert data["aula"]["id"] == aula_id
     assert data["grupo"]["id"] == grupo_id
+
+
+def test_no_permite_superposicion_mismo_grupo(client, session):
+    facultad = Facultad(nombre="Facultad Z")
+    session.add(facultad)
+    session.commit()
+
+    plan = PlanEstudio(nombre="Plan Z", facultad_id=facultad.id)
+    session.add(plan)
+    session.commit()
+
+    docente_uno = Docente(
+        nombre="Docente Tres",
+        correo="docente3@example.com",
+        numero_empleado="EMP003",
+        facultad_id=facultad.id,
+    )
+    docente_dos = Docente(
+        nombre="Docente Cuatro",
+        correo="docente4@example.com",
+        numero_empleado="EMP004",
+        facultad_id=facultad.id,
+    )
+    session.add_all([docente_uno, docente_dos])
+    session.commit()
+
+    aula_uno = Aula(nombre="Aula 301", capacidad=30)
+    aula_dos = Aula(nombre="Aula 302", capacidad=30)
+    materia = Materia(
+        nombre="Materia Z",
+        codigo="MAT301",
+        creditos=3,
+        plan_estudio_id=plan.id,
+    )
+    grupo = Grupo(nombre="Grupo C", plan_estudio_id=plan.id, num_estudiantes=20)
+    session.add_all([aula_uno, aula_dos, materia, grupo])
+    session.commit()
+
+    asignacion_uno = AsignacionMateria(
+        docente_id=docente_uno.id, materia_id=materia.id
+    )
+    asignacion_dos = AsignacionMateria(
+        docente_id=docente_dos.id, materia_id=materia.id
+    )
+    session.add_all([asignacion_uno, asignacion_dos])
+    session.commit()
+
+    disponibilidad_uno = DisponibilidadDocente(
+        docente_id=docente_uno.id,
+        dia=DiaSemanaEnum.lunes,
+        hora_inicio=time(8, 0),
+        hora_fin=time(12, 0),
+    )
+    disponibilidad_dos = DisponibilidadDocente(
+        docente_id=docente_dos.id,
+        dia=DiaSemanaEnum.lunes,
+        hora_inicio=time(8, 0),
+        hora_fin=time(12, 0),
+    )
+    session.add_all([disponibilidad_uno, disponibilidad_dos])
+    session.commit()
+
+    primera_clase = {
+        "docente_id": docente_uno.id,
+        "materia_id": materia.id,
+        "aula_id": aula_uno.id,
+        "grupo_id": grupo.id,
+        "dia": "lunes",
+        "hora_inicio": "09:00 AM",
+        "hora_fin": "10:00 AM",
+    }
+
+    respuesta_primera = client.post("/clases-programadas", json=primera_clase)
+    assert respuesta_primera.status_code == 200
+
+    segunda_clase = {
+        "docente_id": docente_dos.id,
+        "materia_id": materia.id,
+        "aula_id": aula_dos.id,
+        "grupo_id": grupo.id,
+        "dia": "lunes",
+        "hora_inicio": "09:30 AM",
+        "hora_fin": "10:30 AM",
+    }
+
+    respuesta_segunda = client.post("/clases-programadas", json=segunda_clase)
+
+    assert respuesta_segunda.status_code == 400
+    assert "Conflicto" in respuesta_segunda.json()["detail"]


### PR DESCRIPTION
## Summary
- extiende la verificación de conflictos para considerar el grupo y evitar traslapes
- ajusta el router de clases programadas para enviar el identificador del grupo al servicio
- agrega una prueba que garantiza que dos clases del mismo grupo no puedan compartir horario

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c89561996083229dc9c282ec3f42cf