### PR TITLE
Permitir formato 24h en ClaseProgramada

### DIFF
--- a/app/schemas/clase_programada.py
+++ b/app/schemas/clase_programada.py
@@ -29,10 +29,23 @@ class ClaseProgramadaBase(BaseModel):
     @validator("hora_inicio", "hora_fin", pre=True)
     def parsear_hora(cls, value):
         if isinstance(value, str):
-            try:
-                return datetime.strptime(value.strip().upper(), "%I:%M %p").time()
-            except ValueError:
-                raise ValueError("Formato de hora inválido. Use HH:MM AM/PM")
+            valor = value.strip()
+            formatos = [
+                ("%I:%M %p", valor.upper()),
+                ("%H:%M", valor),
+                ("%H:%M:%S", valor),
+            ]
+
+            for formato, valor_a_parsear in formatos:
+                try:
+                    return datetime.strptime(valor_a_parsear, formato).time()
+                except ValueError:
+                    continue
+
+            raise ValueError(
+                "Formato de hora inválido. Use uno de los formatos válidos: "
+                "HH:MM AM/PM, HH:MM (24h), HH:MM:SS (24h)"
+            )
         return value
 
     @validator("hora_fin")


### PR DESCRIPTION
## Summary
- permitir que el validador de horas acepte cadenas en formato 24 horas y enumerar los formatos admitidos
- añadir una prueba de integración que cubra la creación con horas en formato 24 h y el manejo de entradas inválidas

## Testing
- `pytest tests/test_clase_programada.py::test_crear_clase_programada_acepta_formato_24h`


------
https://chatgpt.com/codex/tasks/task_e_68cb52d9bbfc8322a6353254d8e33f72